### PR TITLE
metronome.zk.session_timeout support

### DIFF
--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -6,7 +6,8 @@ function read_env {
     do
       if [[ "$var" =~ ^metronome_ ]]; then
         env_var=`echo "$var" | sed -r "s/(.*)=.*/\1/g"`
-        metronome_property=`echo "$env_var" | tr _ . `
+        # We have to special-case the 'metronome.zk.session_timeout' because it contains an underscore
+        metronome_property=`echo "$env_var" | tr _ . | sed -e 's/session\.timeout/session_timeout/g'`
         opts=$opts"-D$metronome_property=${!env_var} "
       fi
     done


### PR DESCRIPTION
This change adds support for this Java property, which contains an underscore.